### PR TITLE
fix: focus switch in same app will coredump

### DIFF
--- a/src/qtimmodule/qt5/CMakeLists.txt
+++ b/src/qtimmodule/qt5/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(dimplatforminputcontextplugin PRIVATE
   Qt5::DBus
   Qt5::Gui
   Qt5::XkbCommonSupport
+  Qt5::Widgets
   wlc
 )
 

--- a/src/qtimmodule/qt5/DimTextInputV1.h
+++ b/src/qtimmodule/qt5/DimTextInputV1.h
@@ -48,6 +48,9 @@ public:
     void enable() override;
     void disable() override;
 
+private:
+    QObject *focusObjectWrapper(QObject *object) const;
+
 protected:
     void zwp_dim_text_input_v1_enter() override;
     void zwp_dim_text_input_v1_leave() override;

--- a/src/qtimmodule/qt6/CMakeLists.txt
+++ b/src/qtimmodule/qt6/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(dimplatforminputcontextplugin-qt6 PRIVATE
   PkgConfig::wayland-client
   Qt6::GuiPrivate
   Qt6::DBus
+  Qt6::Widgets
   wlc
 )
 


### PR DESCRIPTION
when focus switch, we need to get right focus object, otherwise sendEvent to a error object will be coredump

Log: