### PR TITLE
fix: keyboard is not grabbed after switching applications

### DIFF
--- a/src/imwl/DimTextInputV1.cpp
+++ b/src/imwl/DimTextInputV1.cpp
@@ -135,6 +135,15 @@ void DimTextInputV1::zwp_dim_text_input_v1_disable(wl::server::Resource *resourc
 {
     m_enabled.erase(resource);
 
+    auto i = pidMap_.find(enteredPid_);
+    if (i == pidMap_.end()) {
+        return;
+    }
+
+    if (i->second != resource) {
+        return;
+    }
+
     auto im2 = seat_->getInputMethodV2();
     im2->sendDeactivate();
     im2->sendDone();

--- a/src/imwl/Server.cpp
+++ b/src/imwl/Server.cpp
@@ -8,6 +8,7 @@
 #include "DimTextInputManagerV1.h"
 #include "DimTextInputV1.h"
 #include "InputMethodManagerV2.h"
+#include "InputMethodV2.h"
 #include "Seat.h"
 #include "VirtualKeyboardManagerV1.h"
 #include "X11ActiveWindowMonitor.h"
@@ -75,6 +76,7 @@ void Server::activeWindowChanged(pid_t pid)
     }
 
     qDebug() << "active window changed, pid:" << pid;
+    seat_->getInputMethodV2()->sendDeactivate();
     seat_->getDimTextInputV1()->leavePid(activePid_);
     seat_->getDimTextInputV1()->enterPid(pid);
     activePid_ = pid;


### PR DESCRIPTION
If the window sending the disable is not the currently focused window, deactivate is not called.