### PR TITLE
fix: dim service can not start normal

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -12,3 +12,5 @@ if [ -f $IM_CONFIG_FILE ]; then
         sed -i "$IMConfigPreferredRuleLine s#\,#\,dim\,#g" $IM_CONFIG_FILE
 	fi
 fi
+
+#DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,6 @@
 %:
 	dh $@
 
+override_dh_installsystemduser:
+	dh_installsystemduser --name=org.deepin.dde.dim.service
+	dh_installsystemduser --name=org.deepin.dde.imwl.service


### PR DESCRIPTION
add debian dh_installsystemduser rules to enable dim service when packing

Log: