### PR TITLE
fix: uses the wrong keycode

### DIFF
--- a/src/addons/wlfrontend/WaylandInputContext.cpp
+++ b/src/addons/wlfrontend/WaylandInputContext.cpp
@@ -98,7 +98,7 @@ void WaylandInputContext::commitStringDelegate(InputContext *, const QString &te
 void WaylandInputContext::forwardKeyDelegate(InputContext *, uint32_t keycode, bool pressed) const
 {
     vk_->key(getTimestamp(),
-             keycode + XKB_HISTORICAL_OFFSET,
+             keycode,
              pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 }
 
@@ -251,10 +251,12 @@ void WaylandInputContext::keyCallback(uint32_t serial, uint32_t time, uint32_t k
 
     auto *ic = delegatedInputContext();
 
-    xkb_keysym_t sym = xkb_state_key_get_one_sym(xkbState_.get(), key);
+    uint32_t code = key + XKB_HISTORICAL_OFFSET;
+
+    xkb_keysym_t sym = xkb_state_key_get_one_sym(xkbState_.get(), code);
     InputContextKeyEvent ke(ic,
                             static_cast<uint32_t>(sym),
-                            key,
+                            code,
                             state_->modifiers,
                             state == WL_KEYBOARD_KEY_STATE_RELEASED,
                             time);

--- a/src/imwl/InputMethodKeyboardGrabV2.cpp
+++ b/src/imwl/InputMethodKeyboardGrabV2.cpp
@@ -95,7 +95,9 @@ std::pair<int, size_t> InputMethodKeyboardGrabV2::genKeymapData(xkb_keymap *keym
 
 bool InputMethodKeyboardGrabV2::updateState(uint32_t keycode, bool isRelease)
 {
-    xkb_state_update_key(xkbState_.get(), keycode, isRelease ? XKB_KEY_UP : XKB_KEY_DOWN);
+    xkb_state_update_key(xkbState_.get(),
+                         keycode + XKB_HISTORICAL_OFFSET,
+                         isRelease ? XKB_KEY_UP : XKB_KEY_DOWN);
 
     State state = {};
     state.modsDepressed = xkb_state_serialize_mods(xkbState_.get(), XKB_STATE_MODS_DEPRESSED);

--- a/src/imwl/VirtualKeyboardV1.cpp
+++ b/src/imwl/VirtualKeyboardV1.cpp
@@ -97,7 +97,7 @@ void VirtualKeyboardV1::zwp_virtual_keyboard_v1_key(wl::server::Resource *resour
                                                     uint32_t key,
                                                     uint32_t state)
 {
-    xkb_keysym_t sym = xkb_state_key_get_one_sym(xkbState_.get(), key);
+    xkb_keysym_t sym = xkb_state_key_get_one_sym(xkbState_.get(), key + XKB_HISTORICAL_OFFSET);
     auto dti = seat_->getDimTextInputV1();
     dti->sendKeysym(nextSerial(), time, sym, state, state_.modifiers);
 }

--- a/src/imwl/X11KeyboardGrabber.cpp
+++ b/src/imwl/X11KeyboardGrabber.cpp
@@ -35,7 +35,7 @@ void X11KeyboardGrabber::xcbEvent(const std::unique_ptr<xcb_generic_event_t> &ev
     bool isRelease = ge->event_type == XCB_INPUT_RAW_KEY_RELEASE;
     auto *ke = reinterpret_cast<xcb_input_raw_key_press_event_t *>(event.get());
 
-    emit keyEvent(ke->detail, isRelease);
+    emit keyEvent(ke->detail - XKB_HISTORICAL_OFFSET, isRelease);
 }
 
 void X11KeyboardGrabber::initXinputExtension()


### PR DESCRIPTION
The wayland protocol requires the subtraction
of XKB_HISTORICAL_OFFSET.