### PR TITLE
chore: add missing dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  libudev-dev,
  libwayland-dev,
  libwlroots-dev,
+ libxcb-util-dev,
  libxcb-xinput-dev,
  libxcb1-dev,
  libxkbcommon-dev,


### PR DESCRIPTION
add libxcb-util-dev to dependency